### PR TITLE
when authenticate with admin, search groups with admin

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,18 +179,18 @@ async function authenticateWithAdmin(
   ldapUserClient.unbind()
   if (groupsSearchBase && groupClass) {
     try {
-      ldapUserClient = await _ldapBind(userDn, userPassword, starttls, ldapOpts)
+      ldapAdminClient = await _ldapBind(adminDn, adminPassword, starttls, ldapOpts)
     } catch (error) {
       throw error
     }
     var groups = await _searchUserGroups(
-      ldapUserClient,
+      ldapAdminClient,
       groupsSearchBase,
       user,
       groupClass
     );
     user.groups = groups;
-    ldapUserClient.unbind()
+    ldapAdminClient.unbind()
   }
   return user
 }


### PR DESCRIPTION
When we authenticate with an admin user, I want to make the group lookup with the admin user as well. It is common for LDAP servers to just allow admin users to search in the ldap-tree. So a bind works just fine, but the group lookup is failing. 