### PR TITLE
feat: add group member attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ auth()
 - `starttls`: Boolean. Use `STARTTLS` or not
 - `groupsSearchBase`: if specified with groupClass, will serve as search base for authenticated user groups
 - `groupClass`: if specified with groupsSearchBase, will be used as objectClass in search filter for authenticated user groups
-- `groupMemberAttribute`: if specified with groupClass and groupsSearchBase, will be used as member name (if not specified this default to `member`) in search filter for authenticated user groups
+- `groupMemberAttribute`: if specified with groupClass and groupsSearchBase, will be used as member name (if not specified this defaults to `member`) in search filter for authenticated user groups

--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ auth()
 - `starttls`: Boolean. Use `STARTTLS` or not
 - `groupsSearchBase`: if specified with groupClass, will serve as search base for authenticated user groups
 - `groupClass`: if specified with groupsSearchBase, will be used as objectClass in search filter for authenticated user groups
-- `groupMemberAttribute`: if specified with groupClass and groupSearchBase, will be used as member name (if not specified this default to `member`) in search filter for authenticated user groups
+- `groupMemberAttribute`: if specified with groupClass and groupsSearchBase, will be used as member name (if not specified this default to `member`) in search filter for authenticated user groups

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ let authenticated = await authenticate({
   usernameAttribute: 'uid',
   username: 'gauss',
   groupsSearchBase: 'dc=example,dc=com',
-  groupClass: 'group'
+  groupClass: 'groupOfUniqueNames',
+  groupMemberAttribute: 'uniqueMember',
 })
 ```
 
@@ -152,3 +153,4 @@ auth()
 - `starttls`: Boolean. Use `STARTTLS` or not
 - `groupsSearchBase`: if specified with groupClass, will serve as search base for authenticated user groups
 - `groupClass`: if specified with groupsSearchBase, will be used as objectClass in search filter for authenticated user groups
+- `groupMemberAttribute`: if specified with groupClass and groupSearchBase, will be used as member name (if not specified this default to `member`) in search filter for authenticated user groups

--- a/example/index.js
+++ b/example/index.js
@@ -4,7 +4,7 @@ async function auth() {
   // auth with admin
   let options = {
     ldapOpts: {
-      url: 'ldap://ldapx.forumsys.com',
+      url: 'ldap://ldap.forumsys.com',
       // tlsOptions: { rejectUnauthorized: false }
     },
     adminDn: 'cn=read-only-admin,dc=example,dc=com',
@@ -31,6 +31,24 @@ async function auth() {
     usernameAttribute: 'uid',
     username: 'einstein',
     // starttls: false
+  }
+
+  user = await authenticate(options)
+  console.log(`user = ${JSON.stringify(user, null, 2)}`)
+
+  // Getting user group info
+  options = {
+    ldapOpts: {
+      url: 'ldap://ldap.forumsys.com',
+    },
+    userDn: 'uid=gauss,dc=example,dc=com',
+    userPassword: 'password',
+    userSearchBase: 'dc=example,dc=com',
+    usernameAttribute: 'uid',
+    username: 'gauss',
+    groupsSearchBase: 'dc=example,dc=com',
+    groupClass: 'groupOfUniqueNames',
+    groupMemberAttribute: 'uniqueMember',
   }
 
   user = await authenticate(options)

--- a/index.js
+++ b/index.js
@@ -85,7 +85,13 @@ async function _searchUser(
 }
 
 // search a groups which user is member
-async function _searchUserGroups(ldapClient, searchBase, user, groupClass, groupMemberAttribute) {
+async function _searchUserGroups(
+  ldapClient,
+  searchBase,
+  user,
+  groupClass,
+  groupMemberAttribute = 'member'
+) {
   return new Promise(function (resolve, reject) {
     ldapClient.search(
       searchBase,
@@ -134,7 +140,7 @@ async function authenticateWithAdmin(
   ldapOpts,
   groupsSearchBase,
   groupClass,
-  groupMemberAttribute
+  groupMemberAttribute = 'member'
 ) {
   var ldapAdminClient
   try {
@@ -205,7 +211,7 @@ async function authenticateWithUser(
   ldapOpts,
   groupsSearchBase,
   groupClass,
-  groupMemberAttribute
+  groupMemberAttribute = 'member'
 ) {
   let ldapUserClient
   try {

--- a/index.js
+++ b/index.js
@@ -85,12 +85,12 @@ async function _searchUser(
 }
 
 // search a groups which user is member
-async function _searchUserGroups(ldapClient, searchBase, user, groupClass) {
+async function _searchUserGroups(ldapClient, searchBase, user, groupClass, groupMemberAttribute) {
   return new Promise(function (resolve, reject) {
     ldapClient.search(
       searchBase,
       {
-        filter: `(&(objectclass=${groupClass})(member=${user.dn}))`,
+        filter: `(&(objectclass=${groupClass})(${groupMemberAttribute}=${user.dn}))`,
         scope: 'sub',
       },
       function (err, res) {
@@ -133,7 +133,8 @@ async function authenticateWithAdmin(
   starttls,
   ldapOpts,
   groupsSearchBase,
-  groupClass
+  groupClass,
+  groupMemberAttribute
 ) {
   var ldapAdminClient
   try {
@@ -170,7 +171,7 @@ async function authenticateWithAdmin(
     throw error
   }
   ldapUserClient.unbind()
-  if (groupsSearchBase && groupClass) {
+  if (groupsSearchBase && groupClass && groupMemberAttribute) {
     try {
       ldapAdminClient = await _ldapBind(
         adminDn,
@@ -185,7 +186,8 @@ async function authenticateWithAdmin(
       ldapAdminClient,
       groupsSearchBase,
       user,
-      groupClass
+      groupClass,
+      groupMemberAttribute
     )
     user.groups = groups
     ldapAdminClient.unbind()
@@ -202,7 +204,8 @@ async function authenticateWithUser(
   starttls,
   ldapOpts,
   groupsSearchBase,
-  groupClass
+  groupClass,
+  groupMemberAttribute
 ) {
   let ldapUserClient
   try {
@@ -231,7 +234,7 @@ async function authenticateWithUser(
     )
   }
   ldapUserClient.unbind()
-  if (groupsSearchBase && groupClass) {
+  if (groupsSearchBase && groupClass && groupMemberAttribute) {
     try {
       ldapUserClient = await _ldapBind(userDn, userPassword, starttls, ldapOpts)
     } catch (error) {
@@ -241,7 +244,8 @@ async function authenticateWithUser(
       ldapUserClient,
       groupsSearchBase,
       user,
-      groupClass
+      groupClass,
+      groupMemberAttribute
     )
     user.groups = groups
     ldapUserClient.unbind()
@@ -282,7 +286,8 @@ async function authenticate(options) {
       options.starttls,
       options.ldapOpts,
       options.groupsSearchBase,
-      options.groupClass
+      options.groupClass,
+      options.groupMemberAttribute
     )
   }
   assert(options.userDn, 'adminDn/adminPassword OR userDn must be provided')
@@ -295,7 +300,8 @@ async function authenticate(options) {
     options.starttls,
     options.ldapOpts,
     options.groupsSearchBase,
-    options.groupClass
+    options.groupClass,
+    options.groupMemberAttribute
   )
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,60 @@ describe('ldap-authentication test', () => {
     let user = await authenticate(options)
     expect(user).toBeTruthy()
   })
+  it('Use an admin user to authenticate a regular user and fetch user group information', async () => {
+    let options = {
+      ldapOpts: {
+        url: 'ldap://ldap.forumsys.com',
+      },
+      adminDn: 'cn=read-only-admin,dc=example,dc=com',
+      adminPassword: 'password',
+      userPassword: 'password',
+      userSearchBase: 'dc=example,dc=com',
+      usernameAttribute: 'uid',
+      username: 'gauss',
+      groupsSearchBase: 'dc=example,dc=com',
+      groupClass: 'groupOfUniqueNames',
+      groupMemberAttribute: 'uniqueMember',
+    }
+    let user = await authenticate(options)
+    expect(user).toBeTruthy()
+    expect(user.groups.length).toBeGreaterThan(0)
+  })
+  it('Use regular user to authenticate and fetch user group information', async () => {
+    let options = {
+      ldapOpts: {
+        url: 'ldap://ldap.forumsys.com',
+      },
+      userDn: 'uid=gauss,dc=example,dc=com',
+      userPassword: 'password',
+      userSearchBase: 'dc=example,dc=com',
+      usernameAttribute: 'uid',
+      username: 'gauss',
+      groupsSearchBase: 'dc=example,dc=com',
+      groupClass: 'groupOfUniqueNames',
+      groupMemberAttribute: 'uniqueMember',
+    }
+    let user = await authenticate(options)
+    expect(user).toBeTruthy()
+    expect(user.groups.length).toBeGreaterThan(0)
+  })
+  it('Not specifying groupMemberAttribute should not cause an error and fallback do default value', async () => {
+    let options = {
+      ldapOpts: {
+        url: 'ldap://ldap.forumsys.com',
+      },
+      userDn: 'uid=gauss,dc=example,dc=com',
+      userPassword: 'password',
+      userSearchBase: 'dc=example,dc=com',
+      usernameAttribute: 'uid',
+      username: 'gauss',
+      groupsSearchBase: 'dc=example,dc=com',
+      groupClass: 'groupOfUniqueNames',
+    }
+    let user = await authenticate(options)
+    expect(user).toBeTruthy()
+    expect(user.groups.length).toBeLessThan(1)
+  })
 })
 
 describe('ldap-authentication negative test', () => {


### PR DESCRIPTION
Hi, I saw your nice simple little library for LDAP authentication and started to play around with it. Nice work! I was particularly interested in extracting group information and saw that your example for the forumsys LDAP server wasn't working properly. I looked at the code and saw that the search you do is based on the object class and member attributes, but this last attribute should be uniqueMember for forumsys. So I thought of adding a groupMemberAttribute option. Then, when passing the groupClass option as groupOfUniqueNames and groupMemberAttribute as uniqueMember it finds the group information correctly. Sorry if you find this an unnecessary change, but at least it will make it clear to other users why it won't find group information based on your example? Anyways, glad to hear your thoughts and have a nice evening.