### PR TITLE
fix(types): use connection options from ldapjs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,8 @@
+import { ClientOptions } from 'ldapjs'
+
 declare module 'ldap-authentication' {
-  type LDAPOpts = {
-    url: string
-    tlsOptions?: {
-      rejectUnauthorized: boolean
-    }
-    connectTimeout?: number
-  }
-  export type AuthenticationOptions = {
-    ldapOpts: LDAPOpts
+  export interface AuthenticationOptions {
+    ldapOpts: ClientOptions
     userDn?: string
     adminDn?: string
     adminPassword?: string
@@ -15,7 +10,7 @@ declare module 'ldap-authentication' {
     usernameAttribute?: string
     username?: string
     verifyUserExists?: boolean
-    starttls?: Boolean
+    starttls?: boolean
     groupsSearchBase?: string
     groupClass?: string
     groupMemberAttribute?: string


### PR DESCRIPTION
Hey 👋 

I've enhanced the types to use `ClientOptions` from `ldapjs` because I'm missing some in one of my projects, I don't know why I didn't do the first time, but here it goes the fix 😄 