### PR TITLE
Added raw data to user

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ async function _searchUser(
       }
       res.on('searchEntry', function (entry) {
         user = entry.object
+        user.raw = entry.raw
       })
       res.on('searchReference', function (referral) {
         // TODO: we don't support reference yet


### PR DESCRIPTION
Raw data is needed in order to access buffer objects (profile pics in my case).

Buffer data can now be accessed by `user.raw.profilePhoto`, etc, instead of `user.profilePhoto`.

Taking advantage of a few upstream features/ resolved issues:

https://github.com/ldapjs/node-ldapjs/pull/107
https://github.com/ldapjs/node-ldapjs/blob/2435d1cf9329348df7917b2acfaab107c3ccfef9/lib/messages/search_entry.js#L63 https://github.com/ldapjs/node-ldapjs/issues/290