### PR TITLE
fix: group-search

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ async function _searchUserGroups(
           return
         }
         res.on('searchEntry', function (entry) {
-          groups.push(entry.object)
+          groups.push(entry.pojo)
         })
         res.on('searchReference', function (referral) {})
         res.on('error', function (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ldap-authentication",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ldap-authentication",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "ldapjs": "^3.0.1"


### PR DESCRIPTION
As described by @pizzafroide, in [ldapjs 3.0.0](https://github.com/ldapjs/node-ldapjs/releases/tag/v3.0.0) message objects no longer have a `.object` property which is why the group search would return an array of `undefined`. The property is now called `.pojo`.

This PR simply uses `.pojo` instead of `.object` within the group search.