### PR TITLE
Migrating to ldapts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "ldap-authentication",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ldap-authentication",
-      "version": "3.2.4",
+      "version": "3.2.6",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "ldapjs": "^3.0.7"
+        "ldapts": "^7.3.1"
       },
       "devDependencies": {
         "jasmine": "^5.3.0"
@@ -32,92 +32,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@ldapjs/asn1": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-2.0.0.tgz",
-      "integrity": "sha512-G9+DkEOirNgdPmD0I8nu57ygQJKOOgFEMKknEuQvIHbGLwP3ny1mY+OTUYLCbCaGJP4sox5eYgBJRuSUpnAddA==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md"
-    },
-    "node_modules/@ldapjs/attribute": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@ldapjs/attribute/-/attribute-1.0.0.tgz",
-      "integrity": "sha512-ptMl2d/5xJ0q+RgmnqOi3Zgwk/TMJYG7dYMC0Keko+yZU6n+oFM59MjQOUht5pxJeS4FWrImhu/LebX24vJNRQ==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
-      "dependencies": {
-        "@ldapjs/asn1": "2.0.0",
-        "@ldapjs/protocol": "^1.2.1",
-        "process-warning": "^2.1.0"
-      }
-    },
-    "node_modules/@ldapjs/change": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@ldapjs/change/-/change-1.0.0.tgz",
-      "integrity": "sha512-EOQNFH1RIku3M1s0OAJOzGfAohuFYXFY4s73wOhRm4KFGhmQQ7MChOh2YtYu9Kwgvuq1B0xKciXVzHCGkB5V+Q==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
-      "dependencies": {
-        "@ldapjs/asn1": "2.0.0",
-        "@ldapjs/attribute": "1.0.0"
-      }
-    },
-    "node_modules/@ldapjs/controls": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ldapjs/controls/-/controls-2.1.0.tgz",
-      "integrity": "sha512-2pFdD1yRC9V9hXfAWvCCO2RRWK9OdIEcJIos/9cCVP9O4k72BY1bLDQQ4KpUoJnl4y/JoD4iFgM+YWT3IfITWw==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
-      "dependencies": {
-        "@ldapjs/asn1": "^1.2.0",
-        "@ldapjs/protocol": "^1.2.1"
-      }
-    },
-    "node_modules/@ldapjs/controls/node_modules/@ldapjs/asn1": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-1.2.0.tgz",
-      "integrity": "sha512-KX/qQJ2xxzvO2/WOvr1UdQ+8P5dVvuOLk/C9b1bIkXxZss8BaR28njXdPgFCpj5aHaf1t8PmuVnea+N9YG9YMw==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md"
-    },
-    "node_modules/@ldapjs/dn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ldapjs/dn/-/dn-1.1.0.tgz",
-      "integrity": "sha512-R72zH5ZeBj/Fujf/yBu78YzpJjJXG46YHFo5E4W1EqfNpo1UsVPqdLrRMXeKIsJT3x9dJVIfR6OpzgINlKpi0A==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
-      "dependencies": {
-        "@ldapjs/asn1": "2.0.0",
-        "process-warning": "^2.1.0"
-      }
-    },
-    "node_modules/@ldapjs/filter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ldapjs/filter/-/filter-2.1.1.tgz",
-      "integrity": "sha512-TwPK5eEgNdUO1ABPBUQabcZ+h9heDORE4V9WNZqCtYLKc06+6+UAJ3IAbr0L0bYTnkkWC/JEQD2F+zAFsuikNw==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
-      "dependencies": {
-        "@ldapjs/asn1": "2.0.0",
-        "@ldapjs/protocol": "^1.2.1",
-        "process-warning": "^2.1.0"
-      }
-    },
-    "node_modules/@ldapjs/messages": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ldapjs/messages/-/messages-1.3.0.tgz",
-      "integrity": "sha512-K7xZpXJ21bj92jS35wtRbdcNrwmxAtPwy4myeh9duy/eR3xQKvikVycbdWVzkYEAVE5Ce520VXNOwCHjomjCZw==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
-      "dependencies": {
-        "@ldapjs/asn1": "^2.0.0",
-        "@ldapjs/attribute": "^1.0.0",
-        "@ldapjs/change": "^1.0.0",
-        "@ldapjs/controls": "^2.1.0",
-        "@ldapjs/dn": "^1.1.0",
-        "@ldapjs/filter": "^2.1.1",
-        "@ldapjs/protocol": "^1.2.1",
-        "process-warning": "^2.2.0"
-      }
-    },
-    "node_modules/@ldapjs/protocol": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ldapjs/protocol/-/protocol-1.2.1.tgz",
-      "integrity": "sha512-O89xFDLW2gBoZWNXuXpBSM32/KealKCTb3JGtJdtUQc7RjAk8XzrRgyz02cPAwGKwKPxy0ivuC7UP9bmN87egQ==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md"
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -128,10 +42,23 @@
         "node": ">=14"
       }
     },
-    "node_modules/abstract-logging": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
-      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    "node_modules/@types/asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -157,23 +84,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/backoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
       "dependencies": {
-        "precond": "0.2"
-      },
-      "engines": {
-        "node": ">= 0.6"
+        "safer-buffer": "~2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -209,11 +126,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -228,6 +140,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -239,14 +168,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
-    },
-    "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
-      "engines": [
-        "node >=0.6.0"
-      ]
     },
     "node_modules/foreground-child": {
       "version": "3.2.1",
@@ -341,26 +262,21 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ldapjs": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-3.0.7.tgz",
-      "integrity": "sha512-1ky+WrN+4CFMuoekUOv7Y1037XWdjKpu0xAPwSP+9KdvmV9PG+qOKlssDV6a+U32apwxdD3is/BZcWOYzN30cg==",
-      "deprecated": "This package has been decomissioned. See https://github.com/ldapjs/node-ldapjs/blob/8ffd0bc9c149088a10ec4c1ec6a18450f76ad05d/README.md",
+    "node_modules/ldapts": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-7.3.1.tgz",
+      "integrity": "sha512-g8mxobOSeuxVkXRT9JZBGUvfDjXIpQPEHH5kYG9UjrIlWV5Rqxq+MMmqzlSh4OqSXh+3lFvzyYu+lsJldoZvvA==",
+      "license": "MIT",
       "dependencies": {
-        "@ldapjs/asn1": "^2.0.0",
-        "@ldapjs/attribute": "^1.0.0",
-        "@ldapjs/change": "^1.0.0",
-        "@ldapjs/controls": "^2.1.0",
-        "@ldapjs/dn": "^1.1.0",
-        "@ldapjs/filter": "^2.1.1",
-        "@ldapjs/messages": "^1.3.0",
-        "@ldapjs/protocol": "^1.2.1",
-        "abstract-logging": "^2.0.1",
-        "assert-plus": "^1.0.0",
-        "backoff": "^2.5.0",
-        "once": "^1.4.0",
-        "vasync": "^2.2.1",
-        "verror": "^1.10.1"
+        "@types/asn1": ">=0.2.4",
+        "asn1": "~0.2.6",
+        "debug": "~4.4.0",
+        "strict-event-emitter-types": "~2.0.0",
+        "uuid": "~11.0.4",
+        "whatwg-url": "~14.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/lru-cache": {
@@ -396,13 +312,11 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": {
-        "wrappy": "1"
-      }
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.0",
@@ -435,18 +349,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/precond": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==",
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=6"
       }
     },
-    "node_modules/process-warning": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
-      "integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA=="
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -480,6 +396,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -577,41 +499,57 @@
         "node": ">=8"
       }
     },
-    "node_modules/vasync": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vasync/-/vasync-2.2.1.tgz",
-      "integrity": "sha512-Hq72JaTpcTFdWiNA4Y22Amej2GH3BFmBaKPPlDZ4/oC8HNn2ISHLkFrJU4Ds8R3jcUi7oo5Y9jcMHKjES+N9wQ==",
-      "engines": [
-        "node >=0.6.0"
-      ],
+    "node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "license": "MIT",
       "dependencies": {
-        "verror": "1.10.0"
-      }
-    },
-    "node_modules/vasync/node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
+      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -719,11 +657,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/shaozi/ldap-authentication#readme",
   "dependencies": {
-    "ldapjs": "^3.0.7"
+    "ldapts": "^7.3.1"
   },
   "devDependencies": {
     "jasmine": "^5.3.0"

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -144,8 +144,8 @@ describe('ldap-authentication test', () => {
     let user = await authenticate(options)
     expect(user).toBeTruthy()
     expect(user.groups.length).toBeGreaterThan(0)
-    expect(user.groups[0].objectName).toEqual(
-      'cn=科学A部,ou=users,dc=example,dc=com'
+    expect(user.groups[0].dn).toEqual(
+      'cn=科学A部,ou=groups,dc=example,dc=com'
     )
   })
   it('Use regular user to authenticate and fetch user group information', async () => {
@@ -167,8 +167,8 @@ describe('ldap-authentication test', () => {
     let user = await authenticate(options)
     expect(user).toBeTruthy()
     expect(user.groups.length).toBeGreaterThan(0)
-    expect(user.groups[0].objectName).toEqual(
-      'cn=科学A部,ou=users,dc=example,dc=com'
+    expect(user.groups[0].dn).toEqual(
+      'cn=科学A部,ou=groups,dc=example,dc=com'
     )
   })
   it('Not specifying groupMemberAttribute or groupMemberUserAttribute should not cause an error and fallback to default values', async () => {

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -145,7 +145,7 @@ describe('ldap-authentication test', () => {
     expect(user).toBeTruthy()
     expect(user.groups.length).toBeGreaterThan(0)
     expect(user.groups[0].dn).toEqual(
-      'cn=科学A部,ou=groups,dc=example,dc=com'
+      'cn=科学A部,ou=users,dc=example,dc=com'
     )
   })
   it('Use regular user to authenticate and fetch user group information', async () => {
@@ -168,7 +168,7 @@ describe('ldap-authentication test', () => {
     expect(user).toBeTruthy()
     expect(user.groups.length).toBeGreaterThan(0)
     expect(user.groups[0].dn).toEqual(
-      'cn=科学A部,ou=groups,dc=example,dc=com'
+      'cn=科学A部,ou=users,dc=example,dc=com'
     )
   })
   it('Not specifying groupMemberAttribute or groupMemberUserAttribute should not cause an error and fallback to default values', async () => {


### PR DESCRIPTION
There was a open issue about deprecation of ldapjs, and sugesting ldapts would be a replacement. #63 

So after noticing how this project isn't that big, I made a fork and managed to get it working with ldapts, the only changes was in the _ldapBind, _searchUser and _searchUserGroups functions, with minor adjustments in a test case and everything else worked and all tests passed¹.

Since ldapts seems to do response escaping already, still needs real world testing and investigate if escaping the DN will or will not cause problems with how ldapts works.

> ¹ I ran the tests using the VSCode's devcontainers but even with clean merge these two tests failed, so IDK maybe there is something about it, the difference is in the `Use an admin user to authenticate a regular user and fetch user group information` test returns `cn=科学A部,ou=groups,dc=example,dc=com` for me (30 other tests passed).