### PR TITLE
Added explicitBufferAttributes option to be able to get valid base64 encoded strings from openldap

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare module 'ldap-authentication' {
     groupMemberUserAttribute?: string
     userPassword?: string
     attributes?: string[]
+    explicitBufferAttributes?: string[]
   }
 
   export function authenticate(options: AuthenticationOptions): Promise<any>

--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ async function _searchUser(
   searchBase,
   usernameAttribute,
   username,
-  attributes = null
+  attributes = null,
+  explicitBufferAttributes = null
 ) {
   let filter = new ldapts.EqualityFilter({
     attribute: usernameAttribute,
@@ -73,6 +74,9 @@ async function _searchUser(
   }
   if (attributes) {
     searchOptions.attributes = attributes
+  }
+  if(explicitBufferAttributes) {
+    searchOptions.explicitBufferAttributes = explicitBufferAttributes
   }
 
   // TODO: we don't support reference yet
@@ -102,6 +106,14 @@ async function _searchUser(
   if (user != null && attributes != null) {
     for (let attr of attributes) {
       if (attr.endsWith(';binary') && Buffer.isBuffer(user[attr])) {
+        user[attr] = user[attr].toString('base64')
+      }
+    }
+  }
+  // when attribute is one of the explicitBufferAttributes, should convert to base64 string
+  if (user != null && explicitBufferAttributes != null) {
+    for (let attr of explicitBufferAttributes) {
+      if (Buffer.isBuffer(user[attr])) {
         user[attr] = user[attr].toString('base64')
       }
     }
@@ -170,7 +182,8 @@ async function authenticateWithAdmin(
   groupClass,
   groupMemberAttribute = 'member',
   groupMemberUserAttribute = 'dn',
-  attributes = null
+  attributes = null,
+  explicitBufferAttributes = null
 ) {
   let ldapAdminClient
   try {
@@ -191,7 +204,8 @@ async function authenticateWithAdmin(
     userSearchBase,
     usernameAttribute,
     username,
-    attributes
+    attributes,
+    explicitBufferAttributes
   )
   if (!user || !user.dn) {
     ldapOpts.log &&
@@ -241,7 +255,8 @@ async function authenticateWithUser(
   groupClass,
   groupMemberAttribute = 'member',
   groupMemberUserAttribute = 'dn',
-  attributes = null
+  attributes = null,
+  explicitBufferAttributes = null
 ) {
   let ldapUserClient
   try {
@@ -262,7 +277,8 @@ async function authenticateWithUser(
     userSearchBase,
     usernameAttribute,
     username,
-    attributes
+    attributes,
+    explicitBufferAttributes
   )
   if (!user || !user.dn) {
     ldapOpts.log &&
@@ -301,7 +317,8 @@ async function verifyUserExists(
   groupClass,
   groupMemberAttribute = 'member',
   groupMemberUserAttribute = 'dn',
-  attributes = null
+  attributes = null,
+  explicitBufferAttributes = null
 ) {
   let ldapAdminClient
   try {
@@ -322,7 +339,8 @@ async function verifyUserExists(
     userSearchBase,
     usernameAttribute,
     username,
-    attributes
+    attributes,
+    explicitBufferAttributes
   )
   if (!user || !user.dn) {
     ldapOpts.log &&
@@ -384,7 +402,8 @@ async function authenticate(options) {
       options.groupClass,
       options.groupMemberAttribute,
       options.groupMemberUserAttribute,
-      options.attributes
+      options.attributes,
+      options.explicitBufferAttributes
     )
   }
   assert(options.userPassword, 'userPassword must be provided')
@@ -406,7 +425,8 @@ async function authenticate(options) {
       options.groupClass,
       options.groupMemberAttribute,
       options.groupMemberUserAttribute,
-      options.attributes
+      options.attributes,
+      options.explicitBufferAttributes
     )
   }
   assert(options.userDn, 'adminDn/adminPassword OR userDn must be provided')
@@ -422,7 +442,8 @@ async function authenticate(options) {
     options.groupClass,
     options.groupMemberAttribute,
     options.groupMemberUserAttribute,
-    options.attributes
+    options.attributes,
+    options.explicitBufferAttributes
   )
 }
 

--- a/test/binary.spec.js
+++ b/test/binary.spec.js
@@ -1,0 +1,102 @@
+const { Change } = require('ldapts');
+const { authenticate, LdapAuthenticationError } = require('../index.js')
+const ldapts = require('ldapts');
+const { Attribute } = require('ldapts');
+
+const url = process.env.INGITHUB ? 'ldap://localhost:1389' : 'ldap://ldap:1389'
+
+describe('ldap-authentication binary attributes test', () => {
+
+  const jpegPhotoBase64 = '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDACgcHiMeGSgjISMtKygwPGRBPDc3PHtYXUlkkYCZlo+AjIqgtObDoKrarYqMyP/L2u71////m8H////6/+b9//j/2wBDASstLTw1PHZBQXb4pYyl+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj4+Pj/wAARCACBAGQDAREAAhEBAxEB/8QAGQAAAwEBAQAAAAAAAAAAAAAAAAECAwQF/8QALRAAAgEDAwMCBQQDAAAAAAAAAAECAxEhBBIxMkFRInEFE2GBsRU0QlJikaH/xAAXAQEBAQEAAAAAAAAAAAAAAAAAAQID/8QAGxEBAQEAAwEBAAAAAAAAAAAAAAERAhIhMUH/2gAMAwEAAhEDEQA/APMIAAKAgChp2AdwAAACBlAQUkmu5RkAAACuAAADsAZQDWQKRA7AL7gAEFCbAQDAYAAXAdwBYAogAAAAgokBgADAEr8Ab09JWqZcdq8yJpjb9Pa5qr/ROy4l6Ga6ZxfvgdoYiemqw6o49yoyAAACCiQKa4AAN9PpnWy3aP5Jbiya9ClRhBJRjby/Ji1qRqRQBMkuwMZSk2trdiys2PPqR2zaNspAAIKE0A+yA201H51TPSuSW4smvTilFJJWSOdbi0RTZQghPgK56nNwzXLXtvx4NxhiUAEABQ0nJpJcgejpkoR2rtyznWo3uRpE5S4i8hfRCrPKm0wLlUUUrgZSruXTD/oROZPISuat1s3GGRQgIKADp0kFNy8pYM2rJrshBQ4M1qNErojTOdFyjZTcfqhKWaqFPObuyAdeKlBfRhcZrT01JzXdWsXWc/U7XF5IVlqWm1waYczKhXKIKEB0aOW2uvDwZvxZ9ejbBlq+CLsZaWrMAckvSgpSW6DQVNKW6ObXRUTVd5BmuKp1M05s2USBmaABpS60Qeg41rqUXeMcszjW61auroliyi7sZaFk1YKirVnSVopyXkqajTNtSv3YouXU/oWM8nHLLZWENFCsBiaAB1aCj86tnpjlko9javBlUVY29SWO4VizNaiVBJcu/m5FJwvyFTGmqct+Como3Juz5EZrnZplLKhWAw5NDZxisW47gen8NpqOncsepmarrIBZwwOWunSf+L4ZmxqVnvI1puoU1nObs347BLS7FZLZ8x27sIwqQcJuMuUaRAGdKN5X8ZKHJu+Qrq02venpbNilnGbDB3UNXHUJ7dqmv4szfA46luVnTbf0ZNFyqUpxcKnpv2kUclWiqT9LvF8O5mtRNnZO+ChSTccAOzsGShVhSlullrhFHPObnNyfLKiAHQW2lKfngqxk3dgSyhwm4TUk3dPDIPV0OrhWltmlGr2fkxYrqrUVVg0+ez8GdHPGhLa0/uaRMFeW1K9wrd6e7vJ2XhFRjKnGqtlNtPyyTB5MrqV28nRFxnf3JgogSqp0FBKzRVZlAEKKyFCbjO6eUQexotaq6UKjtUXf+xz5ccWOmas91u2RKVjHZSlaTe210yoipqHNbY3UfyTVEI7nbyUc+r0vLiuFc1Kjz7WNItSxkmCShAAAgCeXewURbTusNBHs6LWRrpQqO1T8nOzGmtamnG1unK9gM4UknfgqNYxSzZsBuTtiOL2ZKPJ1lFU6zt0yymblRhYonuQD4KEAAOXIUkEa6f8AcQ90Sq92r2+5zioXWvY0jQqJkRXn/EeiHuywcS4NI//Z';
+
+  const baseOptions = {
+    ldapOpts: {
+      url: url,
+    },
+    adminDn: 'cn=read-only-admin,dc=example,dc=com',
+    adminPassword: 'password',
+    verifyUserExists: true,
+    userSearchBase: 'dc=example,dc=com',
+    usernameAttribute: 'uid'
+  };
+
+  it('Add jpegPhoto attribute', async () => {
+    let client = new ldapts.Client({
+      ...baseOptions.ldapOpts
+    });
+    try {
+      await client.bind(baseOptions.adminDn, baseOptions.adminPassword);
+
+      // https://github.com/ldapts/ldapts/issues/12
+      await client.modify('cn=gauss,ou=users,dc=example,dc=com', new Change({
+        operation: 'replace',
+        modification: new Attribute({
+          type: 'jpegPhoto',
+          values: [Buffer.from(jpegPhotoBase64, 'base64')],
+        }),
+      }));
+    } finally {
+      await client.unbind();
+    }
+  })
+
+  it('Should return broken jpegPhoto attribute (no attribute selection nor ;binary)', async () => {
+    let user = await authenticate({
+      ...baseOptions,
+      username: 'gauss',
+    })
+
+    expect(user).toBeTruthy()
+    expect(user.uid).toEqual('gauss')
+    expect(user.sn).toEqual('Bar1')
+    expect(typeof user.uidNumber === "string").toBe(true);
+    expect(user.uidNumber).toEqual('1000');
+
+    expect(user.jpegPhoto).toBeDefined();
+    expect(typeof user.jpegPhoto === "string").toBe(true);
+    expect(user.jpegPhoto).not.toEqual(jpegPhotoBase64);    
+  })
+
+  it('Should return nothing in the base64 jpegPhoto (using ;binary)', async () => {
+    let user = await authenticate({
+      ...baseOptions,
+      username: 'gauss',
+      attributes: ['uid', 'sn', 'jpegPhoto;binary'],
+    })
+
+    expect(user).toBeTruthy()
+    expect(user.uid).toEqual('gauss')
+    expect(user.sn).toEqual('Bar1')
+    expect(user.cn).toBeUndefined()
+
+    expect(user.jpegPhoto).toBeUndefined();
+
+    expect(user["jpegPhoto;binary"]).toBeDefined();
+    expect(Array.isArray(user["jpegPhoto;binary"])).toBe(true);
+    expect(user["jpegPhoto;binary"].length).toBe(0);
+  })
+
+  it('Should return base64 jpegPhoto (using explicitBufferAttributes)', async () => {
+    let user = await authenticate({
+      ...baseOptions,
+      username: 'gauss',
+      attributes: ['uid', 'sn', 'jpegPhoto'],
+      explicitBufferAttributes: ['jpegPhoto']
+    })
+
+    expect(user).toBeTruthy()
+    expect(user.uid).toEqual('gauss')
+    expect(user.sn).toEqual('Bar1')
+    expect(user.cn).toBeUndefined()
+
+    expect(user["jpegPhoto;binary"]).toBeUndefined();
+
+    expect(user.jpegPhoto).toBeDefined();
+    expect(typeof user.jpegPhoto === "string").toBe(true);
+    expect(user.jpegPhoto).toEqual(jpegPhotoBase64);
+
+    const buffer = Buffer.from(user.jpegPhoto, 'base64');
+    expect(buffer).toBeDefined();
+    expect(buffer.length).toBeGreaterThan(0);
+  })
+})


### PR DESCRIPTION
As discussed in #82 ;binary option don't work with openldap, so this pull request brings the explicitBufferAttributes option that ldapts uses to workaround this. (More details in The [README of ldapts](https://github.com/ldapts/ldapts?tab=readme-ov-file#return-buffer-for-specific-attribute) )

This change basically add this option when calling the authenticate method, usage is as below
```
const result = await authenticate({
 /** all other options */
 explicitBufferAttributes: ['jpegPhoto']
});
```

> Maybe the README.md should be updated also to reflect how to use this option.

To keep consistency the value is returned as a base64 encoded string the same way `;binary` does when working with compatible ldap servers.

Added tests that update a user with a jpegPhoto attribute containing binary data, then use this option to retrieve the valid info.